### PR TITLE
Offset 0 can be acked for partitions

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -229,7 +229,7 @@ func (c *Consumer) Offset(topic string, partitionID int32) (int64, error) {
 func (c *Consumer) Ack(msg *sarama.ConsumerMessage) {
 	tp := topicPartition{msg.Topic, msg.Partition}
 	c.aLock.Lock()
-	if msg.Offset > c.acked[tp] {
+	if oldOffset, ok := c.acked[tp]; msg.Offset > oldOffset || !ok {
 		c.acked[tp] = msg.Offset
 	}
 	c.aLock.Unlock()

--- a/consumer.go
+++ b/consumer.go
@@ -229,7 +229,7 @@ func (c *Consumer) Offset(topic string, partitionID int32) (int64, error) {
 func (c *Consumer) Ack(msg *sarama.ConsumerMessage) {
 	tp := topicPartition{msg.Topic, msg.Partition}
 	c.aLock.Lock()
-	if oldOffset, ok := c.acked[tp]; msg.Offset > oldOffset || !ok {
+	if msg.Offset >= c.acked[tp] {
 		c.acked[tp] = msg.Offset
 	}
 	c.aLock.Unlock()


### PR DESCRIPTION
We had trouble when acking messages for partitions containing only a single message (which happens quite oftenly in dev). With the patch below, messages with offset 0 can be acked.