### PR TITLE
Add zookeeper dialer to configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: go
 go:
+  - 1.5
   - 1.4
   - 1.3
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ go:
   - 1.3
 install:
   - go get -u github.com/Shopify/sarama
-  - (cd $HOME/gopath/src/github.com/Shopify/sarama && git fetch origin && git reset --hard v1.4.2)
+  - (cd $HOME/gopath/src/github.com/Shopify/sarama && git fetch origin && git reset --hard v1.4.3)
   - go get -t ./...
 env:
   - SCALA_VERSION=2.11 KAFKA_VERSION=0.8.2.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,4 @@ env:
   - SCALA_VERSION=2.10 KAFKA_VERSION=0.8.1.1
 script:
   - make testfull
+sudo: false

--- a/consumer.go
+++ b/consumer.go
@@ -45,6 +45,10 @@ type Config struct {
 	// Default: 1s
 	ZKSessionTimeout time.Duration
 
+	// ZKDialer is the dialer used when connecting to zookeeper.
+	// Default: net.DialTimeout
+	ZKDialer zk.Dialer
+
 	customID     string
 	returnErrors bool
 }
@@ -156,7 +160,7 @@ func NewConsumerFromClient(client sarama.Client, zookeepers []string, group stri
 	}
 
 	// Connect to zookeeper
-	zoo, err := NewZK(zookeepers, config.ZKSessionTimeout)
+	zoo, err := NewZKWithDialer(zookeepers, config.ZKSessionTimeout, config.ZKDialer)
 	if err != nil {
 		scsmr.Close()
 		return nil, err

--- a/zk.go
+++ b/zk.go
@@ -22,7 +22,12 @@ type zkConsumerConfig struct {
 
 // NewZK creates a new connection instance
 func NewZK(servers []string, recvTimeout time.Duration) (*ZK, error) {
-	conn, _, err := zk.Connect(servers, recvTimeout)
+	return NewZKWithDialer(servers, recvTimeout, nil)
+}
+
+// NewZKWithDialer creates a new connection instance using the supplied dialer.
+func NewZKWithDialer(servers []string, recvTimeout time.Duration, dialer zk.Dialer) (*ZK, error) {
+	conn, _, err := zk.ConnectWithDialer(servers, recvTimeout, dialer)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Use to override the default dialer used when connecting to zookeeper,
eg. if you want to turn on keep-alive.