### PR TITLE
Use the default expiration timestamp for OffsetCommitRequest v2.

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -495,6 +495,7 @@ func (c *Consumer) commitOffsets() error {
 		ConsumerGroup:           c.groupID,
 		ConsumerGroupGeneration: c.generationID,
 		ConsumerID:              c.memberID,
+		RetentionTime:           -1,
 	}
 
 	var blocks int


### PR DESCRIPTION
The default value of RetentionTime is 0, so, offset is immediately expire.
In accordance with the DEFAULT_RETENTION_TIME of Java client, to enable the offsets.retention.minutes of Broker Config.