### PR TITLE
Validate groupID for valid characters

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -1,11 +1,14 @@
 package cluster
 
 import (
+	"regexp"
 	"sort"
 	"time"
 
 	"gopkg.in/Shopify/sarama.v1"
 )
+
+var validGroupIDChars *regexp.Regexp = regexp.MustCompile(`\A[A-Za-z0-9._-]*\z`)
 
 // Consumer is a cluster group consumer
 type Consumer struct {
@@ -32,6 +35,12 @@ func NewConsumerFromClient(client *Client, groupID string, topics []string) (*Co
 	csmr, err := sarama.NewConsumerFromClient(client.Client)
 	if err != nil {
 		return nil, err
+	}
+
+	if groupID == "" {
+		return nil, sarama.ConfigurationError("GroupID cannot be empty")
+	} else if !validGroupIDChars.MatchString(groupID) {
+		return nil, sarama.ConfigurationError("GroupID can only contain alphanumerics, '.', '_', and '-'")
 	}
 
 	c := &Consumer{

--- a/consumer_test.go
+++ b/consumer_test.go
@@ -33,6 +33,14 @@ var _ = Describe("Consumer", func() {
 		}()
 	}
 
+	It("should fail for invalid group id", func() {
+		_, err := newConsumer("")
+		Expect(err).To(HaveOccurred())
+
+		_, err = newConsumer("foo:bar")
+		Expect(err).To(HaveOccurred())
+	})
+
 	It("should init and share", func() {
 		cs1, err := newConsumer(testGroup)
 		Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
This performs client-side validation of the group.id property per the Java source: https://github.com/apache/kafka/blob/af0df0961fbc890309137424fe6b16f7c3e0a303/core/src/main/scala/kafka/consumer/ConsumerConfig.scala#L68-L70

See https://github.com/Shopify/sarama/pull/633

Signed-off-by: Byron Ruth <b@devel.io>