### PR TITLE
Reset to configured offset instead of latest on ErrOffsetOutOfRange

### DIFF
--- a/partitions.go
+++ b/partitions.go
@@ -22,7 +22,7 @@ func newPartitionConsumer(manager sarama.Consumer, topic string, partition int32
 
 	// Resume from default offset, if requested offset is out-of-range
 	if err == sarama.ErrOffsetOutOfRange {
-		info.Offset = -1
+		info.Offset = defaultOffset
 		pcm, err = manager.ConsumePartition(topic, partition, defaultOffset)
 	}
 	if err != nil {


### PR DESCRIPTION
In https://github.com/bsm/sarama-cluster/commit/b8422e8c#diff-5ca1e1d791806b5c07f0f2d070e642f9R24 it looks like this was changed to `-1`, which if I'm interpreting correctly, is the latest offset: https://github.com/Shopify/sarama/blob/68920ff1be3bbd31449ab1e2c255c50cedeb755c/client.go#L69-L80

If `sarama`'s `config.Consumer.Offsets.Initial` is set to to `sarama.OffsetOldest`, then wouldn't we also want that when recovering from `ErrOffsetOutOfRange`?

I'll fix the test if there's agreement on the change.