### PR TITLE
More graceful deadline for message processing on rebalancing

### DIFF
--- a/config.go
+++ b/config.go
@@ -14,22 +14,26 @@ type Config struct {
 	Group struct {
 		// The strategy to use for the allocation of partitions to consumers (defaults to StrategyRange)
 		PartitionStrategy Strategy
-		Offsets           struct {
+
+		Offsets struct {
 			Retry struct {
 				// The numer retries when comitting offsets (defaults to 3).
 				Max int
 			}
 		}
+
 		Session struct {
 			// The allowed session timeout for registered consumers (defaults to 30s).
 			// Must be within the allowed server range.
 			Timeout time.Duration
 		}
+
 		Heartbeat struct {
 			// Interval between each heartbeat (defaults to 3s). It should be no more
 			// than 1/3rd of the Group.Session.Timout setting
 			Interval time.Duration
 		}
+
 		// Return specifies which group channels will be populated. If they are set to true,
 		// you must read from the respective channels to prevent deadlock.
 		Return struct {

--- a/consumer_test.go
+++ b/consumer_test.go
@@ -14,6 +14,7 @@ var _ = Describe("Consumer", func() {
 	var newConsumer = func(group string) (*Consumer, error) {
 		config := NewConfig()
 		config.Consumer.Return.Errors = true
+		config.Consumer.MaxProcessingTime = 2 * time.Millisecond
 		return NewConsumer(testKafkaAddrs, group, testTopics, config)
 	}
 

--- a/partitions.go
+++ b/partitions.go
@@ -84,7 +84,11 @@ func (c *partitionConsumer) State() partitionState {
 	}
 
 	c.mutex.Lock()
-	state := c.state
+	state := partitionState{
+		Processed: c.state.Processed,
+		Consumed:  atomic.LoadInt64(&c.state.Consumed),
+		Dirty:     c.state.Dirty,
+	}
 	c.mutex.Unlock()
 
 	return state


### PR DESCRIPTION
This approach keeps track of consumed message offsets. When a rebalance event occurs, it waits for all consumed messages to be processed, waiting for at most `Consumer.MaxProcessingTime * number_of_unprocessed_messages`.

The downside of this approach is that processing on rebalancing happens outside the broker session and heartbeat. If a rebalance occurs and many messages still need to be processed (or the `Consumer.MaxProcessingTime` is high), the consumer may be stuck for quite a while. The broker (group leader) would wait for maximum `Group.Session.Timeout` before assuming for  the consumer to be dead. In that case it will re-assign the partitions to other consumers in the cluster and messages may end up being consumed and processed twice.