### PR TITLE
Do not buffer the multiplexing messages channel

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -52,7 +52,7 @@ func NewConsumerFromClient(client *Client, groupID string, topics []string) (*Co
 		dead:  make(chan none),
 
 		errors:        make(chan error, client.config.ChannelBufferSize),
-		messages:      make(chan *sarama.ConsumerMessage, client.config.ChannelBufferSize),
+		messages:      make(chan *sarama.ConsumerMessage),
 		notifications: make(chan *Notification, 1),
 	}
 	if err := c.client.RefreshCoordinator(groupID); err != nil {
@@ -330,7 +330,7 @@ func (c *Consumer) release() (err error) {
 		err = e
 	}
 
-	// Wait for all messages to be processed
+	// Wait for messages to be processed
 	time.Sleep(c.client.config.Consumer.MaxProcessingTime)
 
 	// Commit offsets


### PR DESCRIPTION
This removes the need to wait for messages to be processed, as only one message may be shifted from the 'stack' at a time. This may have an impact on performance, but it doesn't seem to be the case in my benchmarks.