### PR TITLE
modify PartitionConsumer new and close parallel, make rebalance faster

### DIFF
--- a/cluster_test.go
+++ b/cluster_test.go
@@ -186,3 +186,4 @@ func (*mockConsumer) ConsumePartition(topic string, partition int32, offset int6
 }
 
 func (*mockPartitionConsumer) Close() error { return nil }
+func (*mockPartitionConsumer) AsyncClose()  {}

--- a/consumer.go
+++ b/consumer.go
@@ -325,10 +325,8 @@ func (c *Consumer) handleError(err error) {
 
 // Releases the consumer and commits offsets, called from rebalance() and Close()
 func (c *Consumer) release() (err error) {
-	// Stop all consumers, don't stop on errors
-	if e := c.subs.Stop(); e != nil {
-		err = e
-	}
+	// Stop all consumers, don't take care of error of PartitionConsumer closed.
+	c.subs.Stop()
 
 	// Wait for all messages to be processed
 	time.Sleep(c.client.config.Consumer.MaxProcessingTime)
@@ -410,14 +408,28 @@ func (c *Consumer) subscribe(subs map[string][]int32) error {
 	}
 
 	// Create consumers
+	var wait sync.WaitGroup
+	var mu sync.Mutex
 	for topic, partitions := range subs {
 		for _, partition := range partitions {
-			if err := c.createConsumer(topic, partition, offsets[topic][partition]); err != nil {
-				_ = c.release()
-				_ = c.leaveGroup()
-				return err
-			}
+			wait.Add(1)
+			go func(topic string, partition int32) {
+				cerr := c.createConsumer(topic, partition, offsets[topic][partition])
+				if cerr != nil {
+					mu.Lock()
+					err = cerr
+					mu.Unlock()
+				}
+				wait.Done()
+			}(topic, partition)
 		}
+	}
+
+	wait.Wait()
+	if err != nil {
+		c.release()
+		c.leaveGroup()
+		return err
 	}
 	return nil
 }
@@ -593,7 +605,7 @@ func (c *Consumer) createConsumer(topic string, partition int32, info offsetInfo
 	// Create partitionConsumer
 	pc, err := newPartitionConsumer(c.csmr, topic, partition, info, c.client.config.Consumer.Offsets.Initial)
 	if err != nil {
-		return nil
+		return err
 	}
 
 	// Store in subscriptions

--- a/partitions.go
+++ b/partitions.go
@@ -3,6 +3,7 @@ package cluster
 import (
 	"sort"
 	"sync"
+	"sync/atomic"
 
 	"github.com/Shopify/sarama"
 )
@@ -13,7 +14,7 @@ type partitionConsumer struct {
 	state partitionState
 	mutex sync.Mutex
 
-	closed      bool
+	closed      int32
 	dying, dead chan none
 }
 
@@ -62,19 +63,15 @@ func (c *partitionConsumer) Loop(messages chan<- *sarama.ConsumerMessage, errors
 	}
 }
 
-func (c *partitionConsumer) Close() (err error) {
-	if c.closed {
+func (c *partitionConsumer) Close() {
+	if !atomic.CompareAndSwapInt32(&c.closed, 0, 1) {
 		return
 	}
 
-	c.closed = true
 	close(c.dying)
 	<-c.dead
 
-	if e := c.pcm.Close(); e != nil {
-		err = e
-	}
-	return
+	c.pcm.AsyncClose()
 }
 
 func (c *partitionConsumer) State() partitionState {
@@ -171,23 +168,12 @@ func (m *partitionMap) Snapshot() map[topicPartition]partitionState {
 	return snap
 }
 
-func (m *partitionMap) Stop() (err error) {
+func (m *partitionMap) Stop() {
 	m.mutex.RLock()
-	size := len(m.data)
-	errs := make(chan error, size)
-	for tp := range m.data {
-		go func(p *partitionConsumer) {
-			errs <- p.Close()
-		}(m.data[tp])
+	for _, pcm := range m.data {
+		pcm.Close()
 	}
 	m.mutex.RUnlock()
-
-	for i := 0; i < size; i++ {
-		if e := <-errs; e != nil {
-			err = e
-		}
-	}
-	return
 }
 
 func (m *partitionMap) Clear() {

--- a/partitions_test.go
+++ b/partitions_test.go
@@ -17,8 +17,8 @@ var _ = Describe("partitionConsumer", func() {
 
 	AfterEach(func() {
 		close(subject.dead)
-		Expect(subject.Close()).NotTo(HaveOccurred())
-		Expect(subject.Close()).NotTo(HaveOccurred()) // test that consumer can be closed 2x
+		subject.Close()
+		subject.Close() // test that consumer can be closed 2x
 	})
 
 	It("should set state", func() {


### PR DESCRIPTION
Rebalance procedure takes me minutes, when we get a lot of kafka partitions.
I think using `AsyncClose()` is much safely, because of `partitionConsumer.Loop()` has stopped before we call `AsyncClose()`.