### PR TITLE
Set minimum kafka version, to be compatible with newest version of sarama that supports kafka 0.10.0.0

### DIFF
--- a/config.go
+++ b/config.go
@@ -42,8 +42,10 @@ type Config struct {
 
 // NewConfig returns a new configuration instance with sane defaults.
 func NewConfig() *Config {
+	config := *sarama.NewConfig()
+	config.Version = sarama.V0_9_0_0
 	c := &Config{
-		Config: *sarama.NewConfig(),
+		Config: config,
 	}
 	c.Group.PartitionStrategy = StrategyRange
 	c.Group.Offsets.Retry.Max = 3


### PR DESCRIPTION
Not setting a version results in a Sarama `ErrUnsupportedVersion` error when using the latest version of Sarama that supports Kafka 0.10.0.0