### PR TITLE
Add consumer ready channel

### DIFF
--- a/config.go
+++ b/config.go
@@ -12,6 +12,9 @@ var minVersion = sarama.V0_9_0_0
 type Config struct {
 	sarama.Config
 
+	// Channel to notify when the partition consumers are ready
+	ConsumersReadyCh chan struct{}
+
 	// Group is the namespace for group management properties
 	Group struct {
 		// The strategy to use for the allocation of partitions to consumers (defaults to StrategyRange)

--- a/consumer.go
+++ b/consumer.go
@@ -255,6 +255,12 @@ func (c *Consumer) mainLoop() {
 			c.notifications <- notification
 		}
 
+		// If the ready channel is set, send the alert
+		if c.client.config.ConsumersReadyCh != nil {
+			close(c.client.config.ConsumersReadyCh)
+			c.client.config.ConsumersReadyCh = nil
+		}
+
 		// Wait for signals
 		select {
 		case <-hbDone:


### PR DESCRIPTION
When writing integration tests for our in house codebase, we need to make sure the Sarama consumers are actively listening on a topic before writing data to that topic. We currently use `time.Sleep()` as a hack to give the consumer goroutines time to spin up. If we don't do this, we have a race condition between writing data to a topic, and a consumer listening on that topic.

This PR adds a channel that is notified once the consumers have all started. This allows us to remove `time.Sleep()` from our tests, providing faster and more accurate results.

Does this seem like the correct way to announce that consumers are up and running?