### PR TITLE
Synchronous partition consumer

### DIFF
--- a/config.go
+++ b/config.go
@@ -16,7 +16,11 @@ type Config struct {
 	Group struct {
 		// The strategy to use for the allocation of partitions to consumers (defaults to StrategyRange)
 		PartitionStrategy Strategy
-		Offsets           struct {
+		// Allow only one message per partition in consumer's messages channel
+		// consumer.MarkDone() should be called to ack the processing and allow
+		// another message from this partition to be sent to the channel
+		Sync    bool
+		Offsets struct {
 			Retry struct {
 				// The numer retries when comitting offsets (defaults to 3).
 				Max int

--- a/consumer.go
+++ b/consumer.go
@@ -107,6 +107,10 @@ func (c *Consumer) MarkOffset(msg *sarama.ConsumerMessage, metadata string) {
 	c.subs.Fetch(msg.Topic, msg.Partition).MarkOffset(msg.Offset+1, metadata)
 }
 
+func (c *Consumer) MarkDone(msg *sarama.ConsumerMessage, metadata string) {
+	c.subs.Fetch(msg.Topic, msg.Partition).MarkDone(msg.Offset+1, metadata)
+}
+
 // MarkPartitionOffset marks an offset of the provided topic/partition as processed.
 // See MarkOffset for additional explanation.
 func (c *Consumer) MarkPartitionOffset(topic string, partition int32, offset int64, metadata string) {
@@ -640,7 +644,7 @@ func (c *Consumer) createConsumer(topic string, partition int32, info offsetInfo
 	sarama.Logger.Printf("cluster/consumer %s consume %s/%d from %d\n", c.memberID, topic, partition, info.NextOffset(c.client.config.Consumer.Offsets.Initial))
 
 	// Create partitionConsumer
-	pc, err := newPartitionConsumer(c.csmr, topic, partition, info, c.client.config.Consumer.Offsets.Initial)
+	pc, err := newPartitionConsumer(c.csmr, topic, partition, info, c.client.config.Consumer.Offsets.Initial, c.client.config.Group.Sync)
 	if err != nil {
 		return err
 	}

--- a/partitions.go
+++ b/partitions.go
@@ -13,11 +13,13 @@ type partitionConsumer struct {
 	state partitionState
 	mu    sync.Mutex
 
+	syncSem chan bool
+
 	closed      bool
 	dying, dead chan none
 }
 
-func newPartitionConsumer(manager sarama.Consumer, topic string, partition int32, info offsetInfo, defaultOffset int64) (*partitionConsumer, error) {
+func newPartitionConsumer(manager sarama.Consumer, topic string, partition int32, info offsetInfo, defaultOffset int64, sync bool) (*partitionConsumer, error) {
 	pcm, err := manager.ConsumePartition(topic, partition, info.NextOffset(defaultOffset))
 
 	// Resume from default offset, if requested offset is out-of-range
@@ -29,13 +31,20 @@ func newPartitionConsumer(manager sarama.Consumer, topic string, partition int32
 		return nil, err
 	}
 
-	return &partitionConsumer{
+	pc := &partitionConsumer{
 		pcm:   pcm,
 		state: partitionState{Info: info},
 
 		dying: make(chan none),
 		dead:  make(chan none),
-	}, nil
+	}
+
+	// Sync semaphore
+	if sync {
+		pc.syncSem = make(chan bool, 1)
+	}
+
+	return pc, nil
 }
 
 func (c *partitionConsumer) Loop(messages chan<- *sarama.ConsumerMessage, errors chan<- error) {
@@ -46,6 +55,14 @@ func (c *partitionConsumer) Loop(messages chan<- *sarama.ConsumerMessage, errors
 		case msg, ok := <-c.pcm.Messages():
 			if !ok {
 				return
+			}
+			// Try to lock sync semaphore
+			if c.syncSem != nil {
+				select {
+				case c.syncSem <- true:
+				case <-c.dying:
+					return
+				}
 			}
 			select {
 			case messages <- msg:
@@ -116,6 +133,22 @@ func (c *partitionConsumer) MarkOffset(offset int64, metadata string) {
 		c.state.Dirty = true
 	}
 	c.mu.Unlock()
+}
+
+func (c *partitionConsumer) MarkDone(offset int64, metadata string) {
+	if c == nil {
+		return
+	}
+
+	c.MarkOffset(offset, metadata)
+
+	// Release sync semaphore
+	if c.syncSem != nil {
+		select {
+		case <-c.syncSem:
+		default:
+		}
+	}
 }
 
 // --------------------------------------------------------------------

--- a/partitions_test.go
+++ b/partitions_test.go
@@ -11,7 +11,7 @@ var _ = Describe("partitionConsumer", func() {
 
 	BeforeEach(func() {
 		var err error
-		subject, err = newPartitionConsumer(&mockConsumer{}, "topic", 0, offsetInfo{2000, "m3ta"}, sarama.OffsetOldest)
+		subject, err = newPartitionConsumer(&mockConsumer{}, "topic", 0, offsetInfo{2000, "m3ta"}, sarama.OffsetOldest, false)
 		Expect(err).NotTo(HaveOccurred())
 	})
 
@@ -28,7 +28,7 @@ var _ = Describe("partitionConsumer", func() {
 	})
 
 	It("should recover from default offset if requested offset is out of bounds", func() {
-		pc, err := newPartitionConsumer(&mockConsumer{}, "topic", 0, offsetInfo{200, "m3ta"}, sarama.OffsetOldest)
+		pc, err := newPartitionConsumer(&mockConsumer{}, "topic", 0, offsetInfo{200, "m3ta"}, sarama.OffsetOldest, false)
 		Expect(err).NotTo(HaveOccurred())
 		defer pc.Close()
 		close(pc.dead)
@@ -91,7 +91,7 @@ var _ = Describe("partitionMap", func() {
 	It("should fetch/store", func() {
 		Expect(subject.Fetch("topic", 0)).To(BeNil())
 
-		pc, err := newPartitionConsumer(&mockConsumer{}, "topic", 0, offsetInfo{2000, "m3ta"}, sarama.OffsetNewest)
+		pc, err := newPartitionConsumer(&mockConsumer{}, "topic", 0, offsetInfo{2000, "m3ta"}, sarama.OffsetNewest, false)
 		Expect(err).NotTo(HaveOccurred())
 
 		subject.Store("topic", 0, pc)
@@ -101,9 +101,9 @@ var _ = Describe("partitionMap", func() {
 	})
 
 	It("should return info", func() {
-		pc0, err := newPartitionConsumer(&mockConsumer{}, "topic", 0, offsetInfo{2000, "m3ta"}, sarama.OffsetNewest)
+		pc0, err := newPartitionConsumer(&mockConsumer{}, "topic", 0, offsetInfo{2000, "m3ta"}, sarama.OffsetNewest, false)
 		Expect(err).NotTo(HaveOccurred())
-		pc1, err := newPartitionConsumer(&mockConsumer{}, "topic", 1, offsetInfo{2000, "m3ta"}, sarama.OffsetNewest)
+		pc1, err := newPartitionConsumer(&mockConsumer{}, "topic", 1, offsetInfo{2000, "m3ta"}, sarama.OffsetNewest, false)
 		Expect(err).NotTo(HaveOccurred())
 		subject.Store("topic", 0, pc0)
 		subject.Store("topic", 1, pc1)
@@ -114,9 +114,9 @@ var _ = Describe("partitionMap", func() {
 	})
 
 	It("should create snapshots", func() {
-		pc0, err := newPartitionConsumer(&mockConsumer{}, "topic", 0, offsetInfo{2000, "m3ta"}, sarama.OffsetNewest)
+		pc0, err := newPartitionConsumer(&mockConsumer{}, "topic", 0, offsetInfo{2000, "m3ta"}, sarama.OffsetNewest, false)
 		Expect(err).NotTo(HaveOccurred())
-		pc1, err := newPartitionConsumer(&mockConsumer{}, "topic", 1, offsetInfo{2000, "m3ta"}, sarama.OffsetNewest)
+		pc1, err := newPartitionConsumer(&mockConsumer{}, "topic", 1, offsetInfo{2000, "m3ta"}, sarama.OffsetNewest, false)
 		Expect(err).NotTo(HaveOccurred())
 
 		subject.Store("topic", 0, pc0)


### PR DESCRIPTION
The goal is to be able to concurrently consume messages accross partitions but let processing of messages from the same partition in order to simplify offset managment.

Use case:

```
    for {
        msg := <-messages:
        go func() {
            handle(msg)
            consumer.MarkDone(msg, "delivered")
        }()
    }  
```

With the sync mode, we have the guarantee that we will not handle and commit the (N+1)th message while the Nth could fail.

Another solution should be to expose as many channels as partitions.