### PR TITLE
consumer.StartConsuming: concurrent consuming per partition

### DIFF
--- a/partitions.go
+++ b/partitions.go
@@ -40,6 +40,7 @@ func newPartitionConsumer(manager sarama.Consumer, topic string, partition int32
 
 func (c *partitionConsumer) Loop(messages chan<- *sarama.ConsumerMessage, errors chan<- error) {
 	defer close(c.dead)
+	defer close(messages)
 
 	for {
 		select {


### PR DESCRIPTION
This is a proof of concept implementation of the solution discussed in #93 .

Each partition consumer has its own *sarama.ConsumerMessage channel, and passes this channel to a user-supplied function that runs in a separate goroutine, only for this partition.

This naturally gives us maximum throughput, and the user does not have to manage the goroutines himself.
It feels like a more natural solution to the problem, compared to a semaphore, letting the user-supplied function consume at its own rate.

The biggest issue was that consumer.mainLoop() starts running as soon as the consumer is created, but we cannot have the consuming user-supplied function at this point yet.
I chose to have a separate StartConsuming() function instead of an alternate NewWithConsumingFunc(), though both are possible.
To solve that mainLoop issue, I used a chan consumeStart to signal when the consumeFunc has been set.

I reimplemented Messages() as a special case of StartConsuming().

Please discuss potential problems/improvements !