### PR TITLE
Handle authz limited to specific topics

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -453,15 +453,8 @@ func (c *Consumer) heartbeat() error {
 func (c *Consumer) rebalance() (map[string][]int32, error) {
 	sarama.Logger.Printf("cluster/consumer %s rebalance\n", c.memberID)
 
-	if err := c.client.RefreshMetadata(); err != nil {
-		if err = sarama.ErrTopicAuthorizationFailed {
-			// maybe we don't have authorization to describe all topics
-			if err = c.client.RefreshMetadata(c.coreTopics...); err != nil {
-				return nil, err
-			}
-		} else {
-			return nil, err
-		}
+	if err := c.refreshMetadata(); err != nil {
+		return nil, err
 	}
 
 	if err := c.client.RefreshCoordinator(c.groupID); err != nil {
@@ -782,4 +775,13 @@ func (c *Consumer) isPotentialExtraTopic(topic string) bool {
 		return true
 	}
 	return false
+}
+
+func (c *Consumer) refreshMetadata() error {
+	err := c.client.RefreshMetadata()
+	if err = sarama.ErrTopicAuthorizationFailed {
+		// maybe we didn't have authorization to describe all topics
+		err = c.client.RefreshMetadata(c.coreTopics...)
+	}
+	return err
 }

--- a/consumer.go
+++ b/consumer.go
@@ -779,7 +779,7 @@ func (c *Consumer) isPotentialExtraTopic(topic string) bool {
 
 func (c *Consumer) refreshMetadata() error {
 	err := c.client.RefreshMetadata()
-	if err = sarama.ErrTopicAuthorizationFailed {
+	if err == sarama.ErrTopicAuthorizationFailed {
 		// maybe we didn't have authorization to describe all topics
 		err = c.client.RefreshMetadata(c.coreTopics...)
 	}

--- a/consumer.go
+++ b/consumer.go
@@ -454,13 +454,12 @@ func (c *Consumer) rebalance() (map[string][]int32, error) {
 	sarama.Logger.Printf("cluster/consumer %s rebalance\n", c.memberID)
 
 	if err := c.client.RefreshMetadata(); err != nil {
-		switch err {
-		case sarama.ErrTopicAuthorizationFailed:
+		if err = sarama.ErrTopicAuthorizationFailed {
 			// maybe we don't have authorization to describe all topics
 			if err = c.client.RefreshMetadata(c.coreTopics...); err != nil {
 				return nil, err
 			}
-		default:
+		} else {
 			return nil, err
 		}
 	}


### PR DESCRIPTION
Current behavior: `consumer.rebalance()` starts with `client.RefreshMetadata()` which attempts to describe all topics. If the client only has authorization to describe specific topics, then `sarama.ErrTopicAuthorizationFailed` is returned, rebalance fails, and the `consumer.mainLoop()` starts over.

With this patch, when `sarama.ErrTopicAuthorizationFailed` is returned `consumer.rebalance()` will try calling `client.RefreshMetadata(consumer.coreTopics...)`, and the consumer will successfully subscribe to coreTopics if it has permissions for all of them.