### PR TITLE
Add partition retrieval

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -100,6 +100,9 @@ func (c *Consumer) Notifications() <-chan *Notification { return c.notifications
 // Consistency between partitions is not garanteed since high water marks are updated separately.
 func (c *Consumer) HighWaterMarks() map[string]map[int32]int64 { return c.csmr.HighWaterMarks() }
 
+// Partitions returns the sorted list of all partition IDs for the given topic.
+func (c *Consumer) Partitions(topic string) ([]int32, error) { return c.client.Partitions(topic) }
+
 // MarkOffset marks the provided message as processed, alongside a metadata string
 // that represents the state of the partition consumer at that point in time. The
 // metadata string can be used by another consumer to restore that state, so it


### PR DESCRIPTION
This PR adds the ability to retrieve partition information for a given topic.  It simply forwards the request to the `sarama.Client`.

I find this useful for tools that wish to create consumer groups with `n` consumers where `n` is the number of partitions for a given topic.  Currently, as far as I can tell, the only way to do this (because the client on the returned `cluster.Consumer` is private) is to create `sarama.Consumer` solely to call the `Partitions` function on it and then `Close`.

