### PR TITLE
Allow custom group member UserData to be included when joining the group

### DIFF
--- a/config.go
+++ b/config.go
@@ -48,6 +48,13 @@ type Config struct {
 			// the Whitelist setting.
 			Blacklist *regexp.Regexp
 		}
+
+		Member struct {
+			// Custom metadata to include when joining the group. The user data for all joined members
+			// can be retrieved by sending a DescribeGroupRequest to the broker that is the
+			// coordinator for the group.
+			UserData []byte
+		}
 	}
 }
 

--- a/consumer.go
+++ b/consumer.go
@@ -545,8 +545,9 @@ func (c *Consumer) joinGroup() (*balancer, error) {
 	}
 
 	meta := &sarama.ConsumerGroupMemberMetadata{
-		Version: 1,
-		Topics:  append(c.coreTopics, c.extraTopics...),
+		Version:  1,
+		Topics:   append(c.coreTopics, c.extraTopics...),
+		UserData: c.client.config.Group.Member.UserData,
 	}
 	err := req.AddGroupProtocolMetadata(string(StrategyRange), meta)
 	if err != nil {


### PR DESCRIPTION
This implements the feature request described in #70, allowing custom `UserData` for each member to be included in the `JoinGroupRequest`.