### PR TITLE
Fix off by one error when marking offset

### DIFF
--- a/offsets.go
+++ b/offsets.go
@@ -29,7 +29,7 @@ func (s *OffsetStash) MarkPartitionOffset(topic string, partition int32, offset 
 	defer s.mu.Unlock()
 
 	key := topicPartition{Topic: topic, Partition: partition}
-	if info := s.offsets[key]; offset > info.Offset {
+	if info := s.offsets[key]; offset >= info.Offset {
 		info.Offset = offset
 		info.Metadata = metadata
 		s.offsets[key] = info

--- a/offsets_test.go
+++ b/offsets_test.go
@@ -13,6 +13,15 @@ var _ = Describe("OffsetStash", func() {
 	})
 
 	It("should update", func() {
+		Expect(subject.offsets).To(HaveLen(0))
+
+		subject.MarkPartitionOffset("topic", 0, 0, "m3ta")
+		Expect(subject.offsets).To(HaveLen(1))
+		Expect(subject.offsets).To(HaveKeyWithValue(
+			topicPartition{Topic: "topic", Partition: 0},
+			offsetInfo{Offset: 0, Metadata: "m3ta"},
+		))
+
 		subject.MarkPartitionOffset("topic", 0, 200, "m3ta")
 		Expect(subject.offsets).To(HaveLen(1))
 		Expect(subject.offsets).To(HaveKeyWithValue(


### PR DESCRIPTION
I noticed that I wasn't able to mark an offset of 0 as being processed. This change should fix that.

Note: The `MarkOffset` function in Consumer does the actual offset movement.