### PR TITLE
Allow configurable offset synchronization sleep duration

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -19,6 +19,8 @@ var _ = Describe("Config", func() {
 		Expect(subject.Group.Heartbeat.Interval).To(Equal(3 * time.Second))
 		Expect(subject.Group.Return.Notifications).To(BeFalse())
 		Expect(subject.Metadata.Retry.Max).To(Equal(3))
+		Expect(subject.Group.Offsets.Synchronization.DwellTime).NotTo(BeNil())
+		Expect(*(subject.Group.Offsets.Synchronization.DwellTime)).NotTo(BeZero())
 		// Expect(subject.Config.Version).To(Equal(sarama.V0_9_0_0))
 	})
 

--- a/config_test.go
+++ b/config_test.go
@@ -19,8 +19,7 @@ var _ = Describe("Config", func() {
 		Expect(subject.Group.Heartbeat.Interval).To(Equal(3 * time.Second))
 		Expect(subject.Group.Return.Notifications).To(BeFalse())
 		Expect(subject.Metadata.Retry.Max).To(Equal(3))
-		Expect(subject.Group.Offsets.Synchronization.DwellTime).NotTo(BeNil())
-		Expect(*(subject.Group.Offsets.Synchronization.DwellTime)).NotTo(BeZero())
+		Expect(subject.Group.Offsets.Synchronization.DwellTime).NotTo(BeZero())
 		// Expect(subject.Config.Version).To(Equal(sarama.V0_9_0_0))
 	})
 

--- a/consumer.go
+++ b/consumer.go
@@ -416,7 +416,7 @@ func (c *Consumer) release() (err error) {
 	defer c.subs.Clear()
 
 	// Wait for messages to be processed
-	time.Sleep(c.client.config.Consumer.MaxProcessingTime)
+	time.Sleep(*(c.client.config.Group.Offsets.Synchronization.DwellTime))
 
 	// Commit offsets, continue on errors
 	if e := c.commitOffsetsWithRetry(c.client.config.Group.Offsets.Retry.Max); e != nil {
@@ -659,7 +659,7 @@ func (c *Consumer) fetchOffsets(subs map[string][]int32) (map[string]map[int32]o
 	}
 
 	// Wait for other cluster consumers to process, release and commit
-	time.Sleep(c.client.config.Consumer.MaxProcessingTime * 2)
+	time.Sleep(*(c.client.config.Group.Offsets.Synchronization.DwellTime) * 2)
 
 	broker, err := c.client.Coordinator(c.groupID)
 	if err != nil {

--- a/consumer.go
+++ b/consumer.go
@@ -416,7 +416,10 @@ func (c *Consumer) release() (err error) {
 	defer c.subs.Clear()
 
 	// Wait for messages to be processed
-	time.Sleep(*(c.client.config.Group.Offsets.Synchronization.DwellTime))
+	select {
+		case <-c.dying:
+		case <-time.After(c.client.config.Group.Offsets.Synchronization.DwellTime):
+	}
 
 	// Commit offsets, continue on errors
 	if e := c.commitOffsetsWithRetry(c.client.config.Group.Offsets.Retry.Max); e != nil {
@@ -659,7 +662,12 @@ func (c *Consumer) fetchOffsets(subs map[string][]int32) (map[string]map[int32]o
 	}
 
 	// Wait for other cluster consumers to process, release and commit
-	time.Sleep(*(c.client.config.Group.Offsets.Synchronization.DwellTime) * 2)
+	// Times-two so that we are less likely to "win" a race against a sarama-cluster client that is: 
+	// 1) losing a topic-partition in a rebalance, and therefore:
+	// 2) sleeping to allow some processing to complete, before:
+	// 3) committing the offsets. 
+	// Note that this doesn't necessarily account for the end-to-end latency of the Kafka offsets topic.  
+	time.Sleep(c.client.config.Group.Offsets.Synchronization.DwellTime * 2)
 
 	broker, err := c.client.Coordinator(c.groupID)
 	if err != nil {


### PR DESCRIPTION
github.com/uber/cherami-server has a use case for Sarama and Sarama-cluster where the Sarama MaxProcessingTime needs to be set to a large value. 

This conflicts with the existing use of the MaxProcessingTime in sarama-cluster in a couple of time.Sleeps(), which are used to allow time for a peer Kafka client to commit their final offsets upon loss of a partition in a rebalance. It should be noted that this style of "synchronization" is not strictly "correct", but represents a low-cost, best-effort attempt to reduce duplicate deliveries when rebalancing occurs. It is therefore acceptable that this sleep time is less than the actual MaxProcessingTime. We can have a detailed discussion of the (lack of) consequences to this, if desired. 

This PR proposes to add a new parameter to sarama-cluster, known as the "offset synchronization dwell time", which specifies the duration of these sleeps, separately from the Sarama MaxProcessingTime.

Cherami's motivation for setting a large value for MaxProcessingTime is that Cherami implements a task-queue model on top of the Kafka streaming consumer model. As a consequence, it is expected that there may be "back-pressure" (i.e. periods of benign zero consumption rate), long-running tasks (e.g. up to minutes for a single message), and other scenarios that make the default Sarama MaxProcessingTime invalid for the scenario. The negative consequence of having a low MaxProcessingTime is significant noisy logging, excessive rebalancing, and other "busy-waiting" behavior that wastes resources and reduces determinism.

The design chosen here uses a pointer to time.Duration, since this allows invisible integration and invisible maintenance of the existing behavior with existing bsm/sarama-cluster users, even if they fail to initialize their configuration with NewConfig(), and even if they presently modify the Sarama MaxProcessingTime.