### PR TITLE
Partition handlers

### DIFF
--- a/config.go
+++ b/config.go
@@ -60,6 +60,8 @@ type Config struct {
 			// coordinator for the group.
 			UserData []byte
 		}
+
+		PartitionHandlerFn PartitionHandlerFunc
 	}
 }
 

--- a/consumer.go
+++ b/consumer.go
@@ -729,7 +729,7 @@ func (c *Consumer) createConsumer(topic string, partition int32, info offsetInfo
 
 	var ph PartitionHandler
 	if fn := c.client.config.Group.PartitionHandlerFn; fn != nil {
-		ph = fn(topic, partition, info.Offset, info.Metadata)
+		ph = fn(c, topic, partition, info.Offset, info.Metadata)
 	} else {
 		ph = &partitionHandler{messages: c.messages, errors: c.errors}
 	}

--- a/consumer.go
+++ b/consumer.go
@@ -57,6 +57,7 @@ func NewConsumerFromClient(client *Client, groupID string, topics []string) (*Co
 		messages:      make(chan *sarama.ConsumerMessage),
 		notifications: make(chan *Notification, 1),
 	}
+
 	if err := c.client.RefreshCoordinator(groupID); err != nil {
 		return nil, err
 	}
@@ -83,7 +84,9 @@ func NewConsumer(addrs []string, groupID string, topics []string, config *Config
 
 // Messages returns the read channel for the messages that are returned by
 // the broker.
-func (c *Consumer) Messages() <-chan *sarama.ConsumerMessage { return c.messages }
+func (c *Consumer) Messages() <-chan *sarama.ConsumerMessage {
+	return c.messages
+}
 
 // Errors returns a read channel of errors that occur during offset management, if
 // enabled. By default, errors are logged and not returned over this channel. If
@@ -724,8 +727,15 @@ func (c *Consumer) leaveGroup() error {
 func (c *Consumer) createConsumer(topic string, partition int32, info offsetInfo) error {
 	sarama.Logger.Printf("cluster/consumer %s consume %s/%d from %d\n", c.memberID, topic, partition, info.NextOffset(c.client.config.Consumer.Offsets.Initial))
 
+	var ph PartitionHandler
+	if fn := c.client.config.Group.PartitionHandlerFn; fn != nil {
+		ph = fn(topic, partition, info.Offset, info.Metadata)
+	} else {
+		ph = &partitionHandler{messages: c.messages, errors: c.errors}
+	}
+
 	// Create partitionConsumer
-	pc, err := newPartitionConsumer(c.csmr, topic, partition, info, c.client.config.Consumer.Offsets.Initial)
+	pc, err := newPartitionConsumer(c.csmr, ph, topic, partition, info, c.client.config.Consumer.Offsets.Initial)
 	if err != nil {
 		return err
 	}
@@ -734,7 +744,7 @@ func (c *Consumer) createConsumer(topic string, partition int32, info offsetInfo
 	c.subs.Store(topic, partition, pc)
 
 	// Start partition consumer goroutine
-	go pc.Loop(c.messages, c.errors)
+	go pc.Loop()
 
 	return nil
 }

--- a/partition_handler.go
+++ b/partition_handler.go
@@ -1,0 +1,34 @@
+package cluster
+
+import "github.com/Shopify/sarama"
+
+// PartitionHandler is a handler for subscribing to
+// partition. It will receive messages for this partition.
+type PartitionHandler interface {
+	Messages() chan<- *sarama.ConsumerMessage
+	Errors() chan<- error
+	Close(error)
+}
+
+// PartitionHandlerFunc is a function to be called when a new partition for the group.
+type PartitionHandlerFunc func(topic string, partition int32, offset int64, metadata string) PartitionHandler
+
+// partitionHandler is a default implementation of the PartitionHandler
+// interface.
+type partitionHandler struct {
+	messages chan<- *sarama.ConsumerMessage
+	errors   chan<- error
+}
+
+// Messages implements the PartitionHandler interface.
+func (gph *partitionHandler) Messages() chan<- *sarama.ConsumerMessage {
+	return gph.messages
+}
+
+// Errors implements the PartitionHandler interface.
+func (gph *partitionHandler) Errors() chan<- error {
+	return gph.errors
+}
+
+// Close implements the PartitionHandler interface.
+func (gph *partitionHandler) Close(_ error) {}

--- a/partition_handler.go
+++ b/partition_handler.go
@@ -11,7 +11,7 @@ type PartitionHandler interface {
 }
 
 // PartitionHandlerFunc is a function to be called when a new partition for the group.
-type PartitionHandlerFunc func(topic string, partition int32, offset int64, metadata string) PartitionHandler
+type PartitionHandlerFunc func(consumer *Consumer, topic string, partition int32, offset int64, metadata string) PartitionHandler
 
 // partitionHandler is a default implementation of the PartitionHandler
 // interface.

--- a/partitions_test.go
+++ b/partitions_test.go
@@ -11,7 +11,7 @@ var _ = Describe("partitionConsumer", func() {
 
 	BeforeEach(func() {
 		var err error
-		subject, err = newPartitionConsumer(&mockConsumer{}, "topic", 0, offsetInfo{2000, "m3ta"}, sarama.OffsetOldest)
+		subject, err = newPartitionConsumer(&mockConsumer{}, &partitionHandler{}, "topic", 0, offsetInfo{2000, "m3ta"}, sarama.OffsetOldest)
 		Expect(err).NotTo(HaveOccurred())
 	})
 
@@ -27,7 +27,7 @@ var _ = Describe("partitionConsumer", func() {
 	})
 
 	It("should recover from default offset if requested offset is out of bounds", func() {
-		pc, err := newPartitionConsumer(&mockConsumer{}, "topic", 0, offsetInfo{200, "m3ta"}, sarama.OffsetOldest)
+		pc, err := newPartitionConsumer(&mockConsumer{}, &partitionHandler{}, "topic", 0, offsetInfo{200, "m3ta"}, sarama.OffsetOldest)
 		Expect(err).NotTo(HaveOccurred())
 		defer pc.Close()
 		close(pc.dead)
@@ -88,7 +88,7 @@ var _ = Describe("partitionMap", func() {
 	It("should fetch/store", func() {
 		Expect(subject.Fetch("topic", 0)).To(BeNil())
 
-		pc, err := newPartitionConsumer(&mockConsumer{}, "topic", 0, offsetInfo{2000, "m3ta"}, sarama.OffsetNewest)
+		pc, err := newPartitionConsumer(&mockConsumer{}, &partitionHandler{}, "topic", 0, offsetInfo{2000, "m3ta"}, sarama.OffsetNewest)
 		Expect(err).NotTo(HaveOccurred())
 
 		subject.Store("topic", 0, pc)
@@ -98,9 +98,9 @@ var _ = Describe("partitionMap", func() {
 	})
 
 	It("should return info", func() {
-		pc0, err := newPartitionConsumer(&mockConsumer{}, "topic", 0, offsetInfo{2000, "m3ta"}, sarama.OffsetNewest)
+		pc0, err := newPartitionConsumer(&mockConsumer{}, &partitionHandler{}, "topic", 0, offsetInfo{2000, "m3ta"}, sarama.OffsetNewest)
 		Expect(err).NotTo(HaveOccurred())
-		pc1, err := newPartitionConsumer(&mockConsumer{}, "topic", 1, offsetInfo{2000, "m3ta"}, sarama.OffsetNewest)
+		pc1, err := newPartitionConsumer(&mockConsumer{}, &partitionHandler{}, "topic", 1, offsetInfo{2000, "m3ta"}, sarama.OffsetNewest)
 		Expect(err).NotTo(HaveOccurred())
 		subject.Store("topic", 0, pc0)
 		subject.Store("topic", 1, pc1)
@@ -111,9 +111,9 @@ var _ = Describe("partitionMap", func() {
 	})
 
 	It("should create snapshots", func() {
-		pc0, err := newPartitionConsumer(&mockConsumer{}, "topic", 0, offsetInfo{2000, "m3ta"}, sarama.OffsetNewest)
+		pc0, err := newPartitionConsumer(&mockConsumer{}, &partitionHandler{}, "topic", 0, offsetInfo{2000, "m3ta"}, sarama.OffsetNewest)
 		Expect(err).NotTo(HaveOccurred())
-		pc1, err := newPartitionConsumer(&mockConsumer{}, "topic", 1, offsetInfo{2000, "m3ta"}, sarama.OffsetNewest)
+		pc1, err := newPartitionConsumer(&mockConsumer{}, &partitionHandler{}, "topic", 1, offsetInfo{2000, "m3ta"}, sarama.OffsetNewest)
 		Expect(err).NotTo(HaveOccurred())
 
 		subject.Store("topic", 0, pc0)


### PR DESCRIPTION
I'm running an experiment to separate the consumption of the different partition topics in order to avoid contention on the messages channels. I often have to re-dispatch per partition after receiving a message on the consumer messages channel, which is not ideal, especially when the partition is bound to some local context and handling a new partition requires some initialization.

This is at the experiment stage but I wanted to let you now so you can comment on the approach / implementation if you like.

PartitionHandler is a handler for a specific partition/topic.
It provides better concurrency over partitions by avoiding contention
on the consumer messages channel.
Each partition handler provides its own messages and errors channels which are
bound to the partitionConsumer.