### PR TITLE
notify consumers of rebalance in progress #98

### DIFF
--- a/balancer.go
+++ b/balancer.go
@@ -17,6 +17,9 @@ type Notification struct {
 
 	// Current are topic/partitions that are currently claimed to the consumer
 	Current map[string][]int32
+
+	// Notification that rebalance is in progress
+	RebalanceInProgress bool
 }
 
 func newNotification(released map[string][]int32) *Notification {

--- a/consumer_test.go
+++ b/consumer_test.go
@@ -155,6 +155,20 @@ var _ = Describe("Consumer", func() {
 		select {
 		case n := <-cs.Notifications():
 			Expect(n).To(Equal(&Notification{
+				Claimed:             nil,
+				Released:            nil,
+				Current:             nil,
+				RebalanceInProgress: true,
+			}))
+		case err := <-cs.Errors():
+			Expect(err).NotTo(HaveOccurred())
+		case <-cs.Messages():
+			Fail("expected a notification to arrive before message")
+		}
+
+		select {
+		case n := <-cs.Notifications():
+			Expect(n).To(Equal(&Notification{
 				Claimed: map[string][]int32{
 					"topic-a": {0, 1, 2, 3},
 					"topic-b": {0, 1, 2, 3},
@@ -164,6 +178,7 @@ var _ = Describe("Consumer", func() {
 					"topic-a": {0, 1, 2, 3},
 					"topic-b": {0, 1, 2, 3},
 				},
+				RebalanceInProgress: false,
 			}))
 		case err := <-cs.Errors():
 			Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
the problem with rebalance currently is that downstream consumers have no idea when it’s happening because the `Message()` channel will just block, but they are expected to commit offsets within `Synchronisation.DwellTime`

the workaround is to have a periodic timer and always commit at `Synchronisation.DwellTime / 2` interval, but that’s not ideal for either library or the downstream consumers.

the solution here is to use the `Notifications()` channel to notify downstream consumers of a rebalance in progress, so they can start committing current state, and also has a `MarkConsumersDone()` function that allows downstream consumers to notify sarama-cluster that the clients are ready for rebalancing, instead of waiting for the full `Synchronisation.DwellTime` to pass.