### PR TITLE
Separate out the partitions into separate consumers.

### DIFF
--- a/config.go
+++ b/config.go
@@ -17,7 +17,12 @@ type Config struct {
 	Group struct {
 		// The strategy to use for the allocation of partitions to consumers (defaults to StrategyRange)
 		PartitionStrategy Strategy
-		Offsets           struct {
+
+		// If true, merge all partitions into a single Messages channel.
+		// If false, user must consume each individual partition. (default true)
+		MergePartitions bool
+
+		Offsets struct {
 			Retry struct {
 				// The numer retries when committing offsets (defaults to 3).
 				Max int
@@ -73,6 +78,7 @@ func NewConfig() *Config {
 	c.Group.Offsets.Synchronization.DwellTime = c.Consumer.MaxProcessingTime
 	c.Group.Session.Timeout = 30 * time.Second
 	c.Group.Heartbeat.Interval = 3 * time.Second
+	c.Group.MergePartitions = true
 	c.Config.Version = minVersion
 	return c
 }


### PR DESCRIPTION
I know this looks like a repeat of #147 but I figured I'd add my approach here as a competing approach - I should mention this code has been in use in production at my organization processing billions of messages a week for [well over a year now](https://github.com/crast/sarama-cluster/commit/47bb78316eabb872122acb6fd402e4d5622c0cf6), all I did was rebase it and clean up docs.

(Also worth mentioning, this doesn't break the existing API compatibility, just adds a new method which is enabled by a configuration option)

----

The criteria for this system:

1) Give something which looks like a sarama.PartitionConsumer to allow
portability for existing code to use sarama-cluster with minimal
shimming.

2) Gracefully handle rebalances of partitions / discovering more
partitions by yielding the partitions on a channel as they are
found/added.

3) Maintain a go-like pattern; let the user of the library decide what
to do with each partition, with regards to concurrency, etc... we
don't run goroutines for them, and don't force them to respond to
callbacks on an unknown goroutine.