### PR TITLE
Create consumer from client, and exposing cluster configuration

### DIFF
--- a/client.go
+++ b/client.go
@@ -25,3 +25,8 @@ func NewClient(addrs []string, config *Config) (*Client, error) {
 
 	return &Client{Client: client, config: *config}, nil
 }
+
+// ClusterConfig returns the cluster client configuration.
+func (client *Client) ClusterConfig() *Config {
+	return &client.config
+}

--- a/consumer.go
+++ b/consumer.go
@@ -40,7 +40,11 @@ func NewConsumer(addrs []string, groupID string, topics []string, config *Config
 	if err != nil {
 		return nil, err
 	}
+	return NewConsumerFromClient(client, groupID, topics)
+}
 
+// NewConsumerFromClient initializes a new consumer
+func NewConsumerFromClient(client *Client, groupID string, topics []string) (*Consumer, error) {
 	consumer, err := sarama.NewConsumerFromClient(client.Client)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Adding the ability to create cluster consumer from an already active client, and adding a function to expose cluster configuration to be able to take decisions based on cluster configuration settings like whether to read from notifications channel or not.