### PR TITLE
Add the ability to rewind offsets based on time

### DIFF
--- a/partitions.go
+++ b/partitions.go
@@ -182,6 +182,18 @@ func (c *partitionConsumer) MarkOffset(offset int64, metadata string) {
 	c.mu.Unlock()
 }
 
+func (c *partitionConsumer) RewindOffset(offset int64, metadata string) {
+	if c == nil {
+		return
+	}
+
+	c.mu.Lock()
+	c.state.Info.Offset = offset
+	c.state.Info.Metadata = metadata
+	c.state.Dirty = true
+	c.mu.Unlock()
+}
+
 // --------------------------------------------------------------------
 
 type partitionState struct {


### PR DESCRIPTION
Recent Kafka and sarama has the ability to fetch offsets by timestamp;
see:
https://github.com/Shopify/sarama/wiki/Frequently-Asked-Questions

This is very helpful in cases where we need to rewind the offset and
reset our consumption to some earlier time. Some example is, let's say
the downstream app goes down or something and we need to rewind to some
time earlier.

This patch will help achieve this by rewinding the offset for the given
topic for all the paritions to which this consumer worker subscribes to.
This should make sure we "pause" the current consumption, reset the
offset and then resume (rebalance) the consumption before returning.

Also added a UT to rewind the offset and an example test on how to use
the API