### PR TITLE
Fix the kafka source - 0.9.0.1 testing broken

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 SCALA_VERSION?= 2.12
 KAFKA_VERSION?= 0.10.2.1
 KAFKA_DIR= kafka_$(SCALA_VERSION)-$(KAFKA_VERSION)
-KAFKA_SRC= http://www.mirrorservice.org/sites/ftp.apache.org/kafka/$(KAFKA_VERSION)/$(KAFKA_DIR).tgz
+KAFKA_SRC= https://archive.apache.org/dist/kafka/$(KAFKA_VERSION)/$(KAFKA_DIR).tgz
 KAFKA_ROOT= testdata/$(KAFKA_DIR)
 PKG=$(shell go list ./... | grep -v vendor)
 


### PR DESCRIPTION
Travis tests for 0.9.0.1 is broken on the master. This is due bad kafka mirror.

This might fix the issue.