### PR TITLE
Unify PartitionConsumer interface

### DIFF
--- a/consumer_test.go
+++ b/consumer_test.go
@@ -9,8 +9,6 @@ import (
 	"github.com/Shopify/sarama"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"math/rand"
-	"sync"
 )
 
 var _ = Describe("Consumer", func() {


### PR DESCRIPTION
Fix for #205. The only bit I am unsure of is the fact that `Errors()` is now exposed on the `PartitionConsumer` while being also multiplexed into one big errors channel. I am a little tempted to remove the multiplexing for `Errors` as well.