### PR TITLE
Copy Notification on error to prevent data race (#236)

### DIFF
--- a/balancer.go
+++ b/balancer.go
@@ -68,6 +68,25 @@ func (n *Notification) success(current map[string][]int32) *Notification {
 	return o
 }
 
+func (n *Notification) error() *Notification {
+	o := &Notification{
+		Type:     RebalanceError,
+		Claimed:  make(map[string][]int32),
+		Released: make(map[string][]int32),
+		Current:  make(map[string][]int32),
+	}
+	for topic, partitions := range n.Claimed {
+		o.Claimed[topic] = append(make([]int32, 0, len(partitions)), partitions...)
+	}
+	for topic, partitions := range n.Released {
+		o.Released[topic] = append(make([]int32, 0, len(partitions)), partitions...)
+	}
+	for topic, partitions := range n.Current {
+		o.Current[topic] = append(make([]int32, 0, len(partitions)), partitions...)
+	}
+	return o
+}
+
 // --------------------------------------------------------------------
 
 type topicInfo struct {

--- a/balancer_test.go
+++ b/balancer_test.go
@@ -33,6 +33,27 @@ var _ = Describe("Notification", func() {
 		}))
 	})
 
+	It("should copy on error", func() {
+		n := newNotification(map[string][]int32{
+			"a": {1, 2, 3},
+			"b": {4, 5},
+			"c": {1, 2},
+		})
+		o := n.error()
+
+		Expect(n).To(Equal(&Notification{
+			Type:    RebalanceStart,
+			Current: map[string][]int32{"a": {1, 2, 3}, "b": {4, 5}, "c": {1, 2}},
+		}))
+
+		Expect(o).To(Equal(&Notification{
+			Type:     RebalanceError,
+			Claimed:  map[string][]int32{},
+			Released: map[string][]int32{},
+			Current:  map[string][]int32{"a": {1, 2, 3}, "b": {4, 5}, "c": {1, 2}},
+		}))
+	})
+
 })
 
 var _ = Describe("balancer", func() {

--- a/consumer.go
+++ b/consumer.go
@@ -469,7 +469,8 @@ func (c *Consumer) cmLoop(stopped <-chan none) {
 
 func (c *Consumer) rebalanceError(err error, n *Notification) {
 	if n != nil {
-		n.Type = RebalanceError
+		// Get a copy of the notification that represents the notification's error state
+		n = n.error()
 		c.handleNotification(n)
 	}
 


### PR DESCRIPTION
I could think of a few ways to eliminate this data race, this is the approach that I believe fits best into the project. Any comments are welcome.

Unfortunately I wasn't able to get a test that specifically exercises the data race. If you believe that's necessary before merging this change I can put some more time into it.