### PR TITLE
Fix PartitionConsumer race condition on Close.

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -295,7 +295,7 @@ func (c *Consumer) Close() (err error) {
 		for range c.errors {
 		}
 		for p := range c.partitions {
-			_ = p.Close()
+			p.AsyncClose()
 		}
 		for range c.notifications {
 		}

--- a/partitions.go
+++ b/partitions.go
@@ -86,7 +86,7 @@ func (c *partitionConsumer) InitialOffset() int64 { return c.initialOffset }
 // AsyncClose implements PartitionConsumer
 func (c *partitionConsumer) AsyncClose() {
 	c.closeOnce.Do(func() {
-		c.closeErr = c.PartitionConsumer.Close()
+		c.PartitionConsumer.AsyncClose()
 		close(c.dying)
 	})
 }


### PR DESCRIPTION
Sarama-cluster calls Sarama [Close](https://github.com/Shopify/sarama/blob/master/consumer.go#L281) on [Consumer.Close](https://github.com/bsm/sarama-cluster/blob/master/consumer.go#L298) and [PartitionConsumer.AsyncClose](https://github.com/bsm/sarama-cluster/blob/master/partitions.go#L89). 

When using the sarama-consumer `PartitionConsumer` abstraction, this may result in dataloss, because on rebalance or consumer shutdown, consumer application and sarama will both read from the same `Messages` channel which will result in the application receiving message stream with holes (e.g., offset 100, 102, 104, etc). Since `PartitionConsumer` application is not synchronously notified of rebalance, this diff changes sarama cluster to use `AsyncClose` to prevent this dual drain race condition. 