### PR TITLE
made error handling in PartitionModeConsumer conform to docs

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -824,7 +824,7 @@ func (c *Consumer) createConsumer(tomb *loopTomb, topic string, partition int32,
 	// Start partition consumer goroutine
 	tomb.Go(func(stopper <-chan none) {
 		if c.client.config.Group.Mode == ConsumerModePartitions {
-			pc.waitFor(stopper, c.errors)
+			pc.waitFor(stopper)
 		} else {
 			pc.multiplex(stopper, c.messages, c.errors)
 		}

--- a/partitions.go
+++ b/partitions.go
@@ -98,28 +98,12 @@ func (c *partitionConsumer) Close() error {
 	return c.closeErr
 }
 
-func (c *partitionConsumer) waitFor(stopper <-chan none, errors chan<- error) {
-	defer close(c.dead)
-
-	for {
-		select {
-		case err, ok := <-c.Errors():
-			if !ok {
-				return
-			}
-			select {
-			case errors <- err:
-			case <-stopper:
-				return
-			case <-c.dying:
-				return
-			}
-		case <-stopper:
-			return
-		case <-c.dying:
-			return
-		}
+func (c *partitionConsumer) waitFor(stopper <-chan none) {
+	select {
+	case <-stopper:
+	case <-c.dying:
 	}
+	close(c.dead)
 }
 
 func (c *partitionConsumer) multiplex(stopper <-chan none, messages chan<- *sarama.ConsumerMessage, errors chan<- error) {


### PR DESCRIPTION
While chaos testing some code that uses sarama-consumer in `PartitionModeConsumer`, we happened upon an area where the functionality doesn't correspond to the documentation.  We were listening on the `Errors()` channel on the `PartitionConsumer` as documented, but we found that there was a race where some of the errors were surfacing on the Consumer's error channel and the rest on the partition consumer's.  This patch brings the functionality in line with the docs by removing the loop in the consumer that drains/muxes the partition consumer's errors.  Thanks!