### PR TITLE
Fixed race condition when changing a notification after sending

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -350,7 +350,7 @@ func (c *Consumer) nextTick() {
 
 	// Issue rebalance start notification
 	if c.client.config.Group.Return.Notifications {
-		c.handleNotification(notification)
+		c.handleNotification(newNotification(c.subs.Info())
 	}
 
 	// Rebalance, fetch new subscriptions


### PR DESCRIPTION
Howdy, upstream contributors!

We have been using this awesome repo. I ran into a race condition yesterday in a test. Looked into it a bit and found that the notification was passed through the channel as a pointer and the creator modifies it after. This causes a race with the reader.

Made an one line change and would love to hear what you think! :)