### PR TITLE
Use GroupProtocol chosen by CG Coordinator

### DIFF
--- a/balancer_test.go
+++ b/balancer_test.go
@@ -48,7 +48,7 @@ var _ = Describe("balancer", func() {
 		}
 
 		var err error
-		subject, err = newBalancerFromMeta(client, map[string]sarama.ConsumerGroupMemberMetadata{
+		subject, err = newBalancerFromMeta(client, StrategyRange, map[string]sarama.ConsumerGroupMemberMetadata{
 			"b": {Topics: []string{"three", "one"}},
 			"a": {Topics: []string{"one", "two"}},
 		})
@@ -60,12 +60,13 @@ var _ = Describe("balancer", func() {
 	})
 
 	It("should perform", func() {
-		Expect(subject.Perform(StrategyRange)).To(Equal(map[string]map[string][]int32{
+		Expect(subject.Perform()).To(Equal(map[string]map[string][]int32{
 			"a": {"one": {0, 1}, "two": {0, 1, 2}},
 			"b": {"one": {2, 3}, "three": {0, 1}},
 		}))
 
-		Expect(subject.Perform(StrategyRoundRobin)).To(Equal(map[string]map[string][]int32{
+		subject.strategy = StrategyRoundRobin
+		Expect(subject.Perform()).To(Equal(map[string]map[string][]int32{
 			"a": {"one": {0, 2}, "two": {0, 1, 2}},
 			"b": {"one": {1, 3}, "three": {0, 1}},
 		}))

--- a/consumer.go
+++ b/consumer.go
@@ -676,7 +676,7 @@ func (c *Consumer) joinGroup() (*balancer, error) {
 			return nil, err
 		}
 
-		strategy, err = newBalancerFromMeta(c.client, members)
+		strategy, err = newBalancerFromMeta(c.client, Strategy(resp.GroupProtocol), members)
 		if err != nil {
 			return nil, err
 		}
@@ -701,7 +701,7 @@ func (c *Consumer) syncGroup(strategy *balancer) (map[string][]int32, error) {
 	}
 
 	if strategy != nil {
-		for memberID, topics := range strategy.Perform(c.client.config.Group.PartitionStrategy) {
+		for memberID, topics := range strategy.Perform() {
 			if err := req.AddGroupAssignmentMember(memberID, &sarama.ConsumerGroupMemberAssignment{
 				Topics: topics,
 			}); err != nil {


### PR DESCRIPTION
The CG coordinator chooses a group protocol by inspecting the
ordered protocols in the JoinGroup requests and choosing one that
all members support.  The CG leader is expected to use this choice
to assign partitions.  Currently, though, the protocol on the CG
leader is read from config.  This isn't an issue if all consumers
are using sarama, but if consumers are using mixed libraries, then
it could result in the sarama CG leader choosing a protocol that
is not supported by other consumers.