### PR TITLE
Expose underlying consumer errors

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -21,5 +21,9 @@ const (
 // may be returned through the consumer's Errors() channel
 type Error struct {
 	Ctx string
-	error
+	Err error
+}
+
+func (e Error) Error() string {
+	return e.Err.Error()
 }

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -1,6 +1,7 @@
 package cluster
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -31,6 +32,14 @@ func init() {
 		testKafkaRoot = dir
 	}
 }
+
+var _ = Describe("Error", func() {
+
+	It("should return the error string of the underlying error", func() {
+		Expect(Error{Ctx: "test", Err: errors.New("test message")}.Error()).To(Equal("test message"))
+	})
+
+})
 
 var _ = Describe("offsetInfo", func() {
 

--- a/consumer.go
+++ b/consumer.go
@@ -407,7 +407,7 @@ func (c *Consumer) hbLoop(stopped <-chan none) {
 			case sarama.ErrNotCoordinatorForConsumer, sarama.ErrRebalanceInProgress:
 				return
 			default:
-				c.handleError(&Error{Ctx: "heartbeat", error: err})
+				c.handleError(&Error{Ctx: "heartbeat", Err: err})
 				return
 			}
 		case <-stopped:
@@ -428,7 +428,7 @@ func (c *Consumer) twLoop(stopped <-chan none) {
 		case <-ticker.C:
 			topics, err := c.client.Topics()
 			if err != nil {
-				c.handleError(&Error{Ctx: "topics", error: err})
+				c.handleError(&Error{Ctx: "topics", Err: err})
 				return
 			}
 
@@ -456,7 +456,7 @@ func (c *Consumer) cmLoop(stopped <-chan none) {
 		select {
 		case <-ticker.C:
 			if err := c.commitOffsetsWithRetry(c.client.config.Group.Offsets.Retry.Max); err != nil {
-				c.handleError(&Error{Ctx: "commit", error: err})
+				c.handleError(&Error{Ctx: "commit", Err: err})
 				return
 			}
 		case <-stopped:
@@ -476,7 +476,7 @@ func (c *Consumer) rebalanceError(err error, n *Notification) {
 	switch err {
 	case sarama.ErrRebalanceInProgress:
 	default:
-		c.handleError(&Error{Ctx: "rebalance", error: err})
+		c.handleError(&Error{Ctx: "rebalance", Err: err})
 	}
 
 	select {


### PR DESCRIPTION
Tweaked `Error` to expose the underlying error (as Err) and added `Error() string {...}` to satisfy the error interface.  This would be helpful for reacting to specific error cases (e.g. on sarama.ErrOutOfBrokers connect to a secondary cluster).  Currently, you would need to do a string comparison on `Error()`.