### PR TITLE
fix dying consumer deadlock during rebalance

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -831,7 +831,11 @@ func (c *Consumer) createConsumer(tomb *loopTomb, topic string, partition int32,
 	})
 
 	if c.client.config.Group.Mode == ConsumerModePartitions {
-		c.partitions <- pc
+		select {
+		case c.partitions <- pc:
+		case <-c.dying:
+			pc.Close()
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
We have seamless deploy. When new service is deployed a rebalance begins (at that moment we have the old service and the new one). While rebalance is going on the old service is shutting down and deadlock occurs.